### PR TITLE
Add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/src/OuraMcp"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/tests/OuraMcp.Tests"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Weekly Dependabot checks for NuGet packages and GitHub Actions versions.