### PR TITLE
fix: show friendly CLI errors instead of stack traces

### DIFF
--- a/src/OuraMcp/Program.cs
+++ b/src/OuraMcp/Program.cs
@@ -61,7 +61,7 @@ if (args.Contains("login"))
 {
     try
     {
-        var host = builder.Build();
+        using var host = builder.Build();
         var options = host.Services.GetRequiredService<IOptions<OuraOAuthOptions>>().Value;
         var tokenService = host.Services.GetRequiredService<IOuraTokenService>();
         using var listener = new HttpCallbackListener();
@@ -78,22 +78,25 @@ if (args.Contains("login"))
         Console.Error.WriteLine($"Error: Login failed. {ex.Message}");
         if (debugMode) Console.Error.WriteLine(ex.ToString());
         Console.Error.WriteLine("If the problem persists, try running 'oura-mcp login' again.");
-        Environment.Exit(1);
+        return 1;
     }
 
-    return;
+    return 0;
 }
 
 try
 {
-    await builder.Build().RunAsync();
+    using var host = builder.Build();
+    await host.RunAsync();
 }
 catch (Exception ex)
 {
     Console.Error.WriteLine($"Error: {ex.Message}");
     if (debugMode) Console.Error.WriteLine(ex.ToString());
-    Environment.Exit(1);
+    return 1;
 }
+
+return 0;
 
 /// <summary>
 /// Partial class declaration to make the entry point accessible for integration tests.

--- a/tests/OuraMcp.Tests/ProgramTests.cs
+++ b/tests/OuraMcp.Tests/ProgramTests.cs
@@ -37,25 +37,31 @@ public class ProgramTests
                 psi.Environment[key] = value;
         }
 
-        using var process = Process.Start(psi)!;
+        var process = Process.Start(psi)
+            ?? throw new InvalidOperationException(
+                $"Failed to start process '{psi.FileName}' with arguments '{psi.Arguments}'.");
 
-        // Drain stdout concurrently to prevent deadlocks
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-
-        using var cts = new CancellationTokenSource(timeoutMs);
-        try
+        using (process)
         {
-            await process.WaitForExitAsync(cts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException($"Process did not exit within {timeoutMs}ms");
-        }
+            // Drain stdout and stderr concurrently to prevent deadlocks
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
 
-        var stderr = await stderrTask;
-        return (process.ExitCode, stderr);
+            using var cts = new CancellationTokenSource(timeoutMs);
+            try
+            {
+                await process.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                throw new TimeoutException($"Process did not exit within {timeoutMs}ms");
+            }
+
+            var stderr = await stderrTask;
+            await stdoutTask;
+            return (process.ExitCode, stderr);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Replaces raw `InvalidOperationException` crashes with clean, actionable error messages when environment variables are missing or login fails.

### Before
```
Unhandled exception. System.InvalidOperationException: OURA_CLIENT_ID is required
   at Program.<>c__DisplayClass0_0.<<Main>$>b__1(OuraOAuthOptions opts) in ...
   at Microsoft.Extensions.Options.ConfigureNamedOptions`1.Configure(...)
   ...
```

### After
```
Error: Required environment variable(s) not set: OURA_CLIENT_ID, OURA_CLIENT_SECRET
Set them before running oura-mcp. For example:

  export OURA_CLIENT_ID=<your-value>
  export OURA_CLIENT_SECRET=<your-value>

See https://github.com/gjlumsden/oura-mcp#setup for details.
```

## Changes

- **`Program.cs`**: Validate `OURA_CLIENT_ID` / `OURA_CLIENT_SECRET` early with a friendly stderr message and `Environment.Exit(1)` — no stack trace. Wrap login flow and server startup in try/catch for clean error output.
- **`ProgramTests.cs`** (new): 4 integration tests verifying:
  - Missing both env vars → friendly error listing both, non-zero exit
  - Missing only `OURA_CLIENT_ID` → lists only that var
  - Missing only `OURA_CLIENT_SECRET` → lists only that var
  - `login` command with missing vars → friendly error, no stack trace

## Testing

All 122 tests pass (118 existing + 4 new).

Closes #16