### PR TITLE
docs: update Oura developer portal links to developer.ouraring.com

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ tests/OuraMcp.Tests/      # Unit/integration tests
 ## Rules
 
 1. **Consult docs before coding.** Authoritative sources:
-   - Oura API v2: https://cloud.ouraring.com/v2/docs
+   - Oura API v2: https://developer.ouraring.com/
    - .NET MCP SDK: https://learn.microsoft.com/en-us/dotnet/ai/get-started-mcp
    - MCP spec: https://modelcontextprotocol.io/docs/getting-started/intro
 2. Never guess API shapes or SDK signatures — look them up.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/download/dotnet/10.0)
 [![MCP](https://img.shields.io/badge/MCP-1.1.0-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0wIDE4Yy00LjQyIDAtOC0zLjU4LTgtOHMzLjU4LTggOC04IDggMy41OCA4IDgtMy41OCA4LTggOHoiLz48L3N2Zz4=)](https://modelcontextprotocol.io/)
-[![Oura API v2](https://img.shields.io/badge/Oura_API-v2-000000)](https://cloud.ouraring.com/v2/docs)
+[![Oura API v2](https://img.shields.io/badge/Oura_API-v2-000000)](https://developer.ouraring.com/)
 [![NuGet](https://img.shields.io/nuget/v/gjlumsden.OuraMcp?logo=nuget)](https://www.nuget.org/packages/gjlumsden.OuraMcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A **.NET 10 MCP server** that exposes [Oura Ring](https://ouraring.com/) health and wellness data as [Model Context Protocol](https://modelcontextprotocol.io/) tools for AI assistants.
 
-> **Disclaimer:** This is an independently developed open source project. It is not affiliated with, endorsed by, or sponsored by Ōura Health Oy. "Oura" and "Oura Ring" are trademarks of Ōura Health Oy. This project uses the [Oura API v2](https://cloud.ouraring.com/v2/docs) but is not maintained or supported by Oura. For official Oura support, visit [ouraring.com](https://ouraring.com/).
+> **Disclaimer:** This is an independently developed open source project. It is not affiliated with, endorsed by, or sponsored by Ōura Health Oy. "Oura" and "Oura Ring" are trademarks of Ōura Health Oy. This project uses the [Oura API v2](https://developer.ouraring.com/) but is not maintained or supported by Oura. For official Oura support, visit [ouraring.com](https://ouraring.com/).
 
 ## Overview
 
@@ -19,7 +19,7 @@ This server connects to the **Oura API v2** and surfaces ring data — sleep, ac
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-- An Oura API application registered at <https://cloud.ouraring.com/oauth/applications> (redirect URI: `http://localhost:8742/callback/`)
+- An Oura API application registered at <https://developer.ouraring.com/> (redirect URI: `http://localhost:8742/callback/`)
 
 ### 1. Install
 


### PR DESCRIPTION
## Summary

Updates all human-facing Oura developer portal links from the old `cloud.ouraring.com` URLs to `https://developer.ouraring.com/`.

## Changes

- **`README.md`** — Badge link, disclaimer link, and app registration link all point to `developer.ouraring.com`
- **`.github/copilot-instructions.md`** — Oura API v2 doc reference updated

## Not changed

The OAuth authorize endpoint (`cloud.ouraring.com/oauth/authorize`) in `OuraOAuthOptions.cs` is a functional runtime URL and was intentionally left as-is.

Closes #19