### PR TITLE
fix: improve 403 error handling with logging and friendly MCP messages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,8 @@ tests/OuraMcp.Tests/      # Unit/integration tests
 ## Rules
 
 1. **Consult docs before coding.** Authoritative sources:
-   - Oura API v2: https://cloud.ouraring.com/v2/docs
+   - Oura API v2: https://cloud.ouraring.com/v2/docs (OpenAPI spec: https://cloud.ouraring.com/v2/static/json/openapi-1.28.json)
+   - Oura developer portal: https://developer.ouraring.com/
    - .NET MCP SDK: https://learn.microsoft.com/en-us/dotnet/ai/get-started-mcp
    - MCP spec: https://modelcontextprotocol.io/docs/getting-started/intro
 2. Never guess API shapes or SDK signatures — look them up.

--- a/src/OuraMcp/OuraClient/OuraApiClient.cs
+++ b/src/OuraMcp/OuraClient/OuraApiClient.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using OuraMcp.Auth;
 using OuraMcp.OuraClient.Models;
 
@@ -14,16 +16,18 @@ public class OuraApiClient : IOuraApiClient
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOuraTokenService _tokenService;
+    private readonly ILogger<OuraApiClient> _logger;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = false
     };
 
-    public OuraApiClient(IHttpClientFactory httpClientFactory, IOuraTokenService tokenService)
+    public OuraApiClient(IHttpClientFactory httpClientFactory, IOuraTokenService tokenService, ILogger<OuraApiClient> logger)
     {
         _httpClientFactory = httpClientFactory;
         _tokenService = tokenService;
+        _logger = logger;
     }
 
     // ── Single-object endpoints ──────────────────────────────────────
@@ -139,11 +143,15 @@ public class OuraApiClient : IOuraApiClient
             response = await SendAuthorizedAsync(url, accessToken, ct);
         }
 
-        // 403 → throw with meaningful message
+        // 403 → log the raw response and throw a user-friendly MCP error
         if (response.StatusCode == HttpStatusCode.Forbidden)
         {
             var body = await response.Content.ReadAsStringAsync(ct);
-            throw new HttpRequestException($"403 Forbidden: {body}");
+            _logger.LogWarning("Oura API returned 403 Forbidden for {Url}: {Body}", url, body);
+            throw new McpException(
+                $"Access denied for '{url}'. This usually means your Oura subscription has expired " +
+                "or your account doesn't have access to this data type. " +
+                "Check your subscription status in the Oura app.");
         }
 
         response.EnsureSuccessStatusCode();

--- a/tests/OuraMcp.Tests/OuraClient/OuraApiClientTests.cs
+++ b/tests/OuraMcp.Tests/OuraClient/OuraApiClientTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using Moq;
 using Moq.Protected;
 using OuraMcp.Auth;
@@ -16,6 +18,7 @@ public class OuraApiClientTests
     private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
     private readonly Mock<IOuraTokenService> _tokenService = new();
     private readonly Mock<HttpMessageHandler> _httpHandler = new();
+    private readonly Mock<ILogger<OuraApiClient>> _logger = new();
 
     private OuraApiClient CreateClient()
     {
@@ -31,7 +34,7 @@ public class OuraApiClientTests
             .Setup(t => t.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(FakeToken);
 
-        return new OuraApiClient(_httpClientFactory.Object, _tokenService.Object);
+        return new OuraApiClient(_httpClientFactory.Object, _tokenService.Object, _logger.Object);
     }
 
     private void SetupHttpResponse(HttpStatusCode statusCode, string content)
@@ -235,7 +238,7 @@ public class OuraApiClientTests
     }
 
     [Fact]
-    public async Task ApiCall_403Response_ThrowsMeaningfulException()
+    public async Task ApiCall_403Response_ThrowsMcpExceptionWithFriendlyMessage()
     {
         var forbiddenJson = """{"detail":"Subscription expired"}""";
         SetupHttpResponse(HttpStatusCode.Forbidden, forbiddenJson);
@@ -243,8 +246,8 @@ public class OuraApiClientTests
 
         var act = () => client.GetPersonalInfoAsync();
 
-        await act.Should().ThrowAsync<HttpRequestException>()
-            .Where(e => e.Message.Contains("403") || e.Message.Contains("Forbidden") || e.Message.Contains("Subscription"));
+        await act.Should().ThrowAsync<McpException>()
+            .Where(e => e.Message.Contains("Access denied") && e.Message.Contains("subscription"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes generic invocation errors for tools that hit Oura API 403 responses (e.g. `get_daily_resilience`, `get_vo2_max`, `get_cardiovascular_age`) by replacing raw `HttpRequestException` with `McpException` that surfaces a clear, actionable message to the MCP client.

### Before
```
Error: Generic invocation error
```

### After
```
Access denied for 'v2/usercollection/daily_resilience'. This usually means your Oura subscription
has expired or your account doesn't have access to this data type. Check your subscription status
in the Oura app.
```

## Changes

- **`OuraApiClient.cs`** — Added `ILogger<OuraApiClient>` and `McpException`:
  - Logs the full 403 response body at `Warning` level for diagnostics
  - Throws `McpException` with a user-friendly message explaining likely causes (expired subscription, insufficient data)
- **`OuraApiClientTests.cs`** — Updated 403 test to assert `McpException` with friendly message; added logger mock
- **`.github/copilot-instructions.md`** — Added OpenAPI spec URL and developer portal reference alongside the existing API docs URL

## Verification

- Audited all 18 tools against the [OpenAPI spec v1.28](https://cloud.ouraring.com/v2/static/json/openapi-1.28.json): all endpoints, paths, and models are correct
- All 118 tests pass

Closes #22