### PR TITLE
chore: update all dependencies

### DIFF
--- a/src/OuraMcp/OuraMcp.csproj
+++ b/src/OuraMcp/OuraMcp.csproj
@@ -34,11 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.*" />

--- a/tests/OuraMcp.Tests/OuraMcp.Tests.csproj
+++ b/tests/OuraMcp.Tests/OuraMcp.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />


### PR DESCRIPTION
Combines all outstanding dependabot PRs into a single update:

- **Microsoft.AspNetCore.DataProtection** 10.0.3 → 10.0.5 (#33)
- **Microsoft.Extensions.Caching.Memory** 10.0.4 → 10.0.5 (#34)
- **Microsoft.Extensions.Hosting** 10.0.3 → 10.0.5 (#35)
- **Microsoft.Extensions.Http** 10.0.3 → 10.0.5 (#36)
- **Microsoft.Extensions.Http.Resilience** 10.3.0 → 10.4.0 (#37)
- **coverlet.collector** 8.0.0 → 8.0.1 (#38)

All 186 tests pass locally. Closes #33, #34, #35, #36, #37, #38.