### PR TITLE
Bump Extensions.Caching.Memory, Http, and Http.Resilience

### DIFF
--- a/src/OuraMcp/OuraMcp.csproj
+++ b/src/OuraMcp/OuraMcp.csproj
@@ -35,10 +35,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.*" />


### PR DESCRIPTION
## Summary

Consolidates the remaining Dependabot version bumps that conflicted after the earlier batch of merges.

| Package | From | To |
|---|---|---|
| \Microsoft.Extensions.Caching.Memory\ | 10.0.8 | 10.0.9 |
| \Microsoft.Extensions.Http\ | 10.0.8 | 10.0.9 |
| \Microsoft.Extensions.Http.Resilience\ | 10.6.0 | 10.7.0 |

\Http.Resilience\ 10.7.0 transitively requires \Http >= 10.0.9\, so these three are bumped together to prevent the NU1605 package-downgrade build error.

Build verified locally: \dotnet build\ succeeds with 0 errors, 0 warnings.