### PR TITLE
fix(release): replace softprops action with gh CLI to prevent duplicate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
         run: dotnet nuget push ./nupkg/*.nupkg --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" --source https://www.nuget.org/api/v2/package --skip-duplicate
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ./nupkg/*.nupkg
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" ./nupkg/*.nupkg \
+            --title "${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
## Problem

`softprops/action-gh-release@v3` with `generate_release_notes: true` was producing a duplicated changelog body in GitHub releases. The action called the GitHub Releases API with `generate_release_notes: true` and also generated notes itself, resulting in two identical "What's Changed" sections.

## Fix

Replace the third-party action with the `gh` CLI:

```bash
gh release create "${{ github.ref_name }}" ./nupkg/*.nupkg \
  --title "${{ github.ref_name }}" \
  --generate-notes
```

`gh release create --generate-notes` calls the API exactly once, producing a single clean changelog.

## Testing

Will be validated on the next release tag push.